### PR TITLE
Provide Sender to Broadcaster surface updates plus minor changes

### DIFF
--- a/Screenary/Screenary.csproj
+++ b/Screenary/Screenary.csproj
@@ -60,6 +60,7 @@
     <Compile Include="Transport\Channel.cs" />
     <Compile Include="Session\ISessionResponseListener.cs" />
     <Compile Include="Session\ISessionRequestListener.cs" />
+    <Compile Include="Surface\ISurfaceServer.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/Screenary/Surface/ISurfaceServer.cs
+++ b/Screenary/Surface/ISurfaceServer.cs
@@ -1,0 +1,11 @@
+using System;
+using System.IO;
+
+namespace Screenary
+{
+	public interface ISurfaceServer
+	{
+		void OnSurfaceCommand(char[] sessionKey, byte[] buffer);
+	}
+}
+

--- a/Screenary/Surface/SurfaceChannel.cs
+++ b/Screenary/Surface/SurfaceChannel.cs
@@ -12,8 +12,11 @@ namespace Screenary
 		protected TransportClient transport;
 		
 		public const UInt16 PDU_CHANNEL_SURFACE = 0x0001;
-		
-		public const byte PDU_SURFACE_COMMAND = 0x01;
+				
+		/* From Sender */
+		public const byte PDU_SURFACE_COMMAND_SENDER = 0x01;
+		/* To Receivers */
+		public const byte PDU_SURFACE_COMMAND_RECEIVER = 0x02;
 		
 		public SurfaceChannel()
 		{

--- a/Screenary/Surface/SurfaceClient.cs
+++ b/Screenary/Surface/SurfaceClient.cs
@@ -17,8 +17,36 @@ namespace Screenary
 			this.transport = transport;
 		}
 		
+		/*
+		 * Send surface commands to broadcaster
+		 * 
+		 * @param pduBuffer
+		 * @param sessionKey
+		 */
+		public void SendSurfaceCommand(byte[] pduBuffer, char[] sessionKey)
+		{
+			Console.WriteLine("SurfaceClient.SendSurfaceCommand");
+
+			int length = sessionKey.Length + 2 + pduBuffer.Length;
+			byte[] buffer = new byte[length];
+
+			BinaryWriter s = new BinaryWriter(new MemoryStream(buffer));
+			
+			s.Write(sessionKey);
+			s.Write((UInt16)buffer.Length);
+			s.Write(pduBuffer);
+			
+			Send(buffer, PDU_SURFACE_COMMAND_SENDER);
+		}
+		
+		/*
+		 * Receive surface updates from broadcaster
+		 * 
+		 * @param s
+		 */
 		private bool RecvSurfaceCommand(BinaryReader s)
 		{
+			Console.WriteLine("SurfaceClient.RecvSurfaceCommand");
 			client.OnSurfaceCommand(s);
 			return true;
 		}
@@ -53,11 +81,11 @@ namespace Screenary
 			MemoryStream stream = new MemoryStream(buffer);
 			BinaryReader s = new BinaryReader(stream);
 			
-			pduType = PDU_SURFACE_COMMAND;
+			pduType = PDU_SURFACE_COMMAND_SENDER;
 			
 			switch (pduType)
 			{
-				case PDU_SURFACE_COMMAND:
+				case PDU_SURFACE_COMMAND_SENDER:
 					RecvSurfaceCommand(s);
 					return;
 				

--- a/Screenary/Surface/SurfaceServer.cs
+++ b/Screenary/Surface/SurfaceServer.cs
@@ -1,21 +1,53 @@
 using System;
 using System.Threading;
 using System.Collections;
+using System.IO;
 
 namespace Screenary
 {
 	public class SurfaceServer : SurfaceChannel
 	{
 		private readonly object channelLock = new object();
+		private ISurfaceServer listener;
 		
-		public SurfaceServer(TransportClient transport)
+		public SurfaceServer(ISurfaceServer listener, TransportClient transport)
 		{
+			this.listener = listener;
 			this.transport = transport;
 		}
 		
+		/*
+		 * Send surface commands to client
+		 * 
+		 * @param pduBuffer
+		 * @param sessionKey
+		 */
 		public void SendSurfaceCommand(byte[] buffer)
 		{
-			transport.SendPDU(buffer, PDU_CHANNEL_SURFACE, PDU_SURFACE_COMMAND);
+			Console.WriteLine("SurfaceServer.SendSurfaceCommand");
+
+			Send(buffer, PDU_SURFACE_COMMAND_RECEIVER);
+		}
+		
+		/*
+		 * Receive surface updates from client
+		 * 
+		 * @param s
+		 */
+		private void RecvSurfaceCommand(BinaryReader s)
+		{
+			Console.WriteLine("SurfaceServer.RecvSurfaceCommand");
+			
+			char[] sessionKey = s.ReadChars(12);
+			int bufferLength = s.ReadInt16();
+
+			Console.WriteLine("SessionKey: {0}, ByteLength: {1}", new string(sessionKey), bufferLength);
+
+			if (bufferLength > 0) 
+			{
+				byte[] buffer = s.ReadBytes(bufferLength);
+				listener.OnSurfaceCommand(sessionKey, buffer);
+			}
 		}
 		
 		public override void OnRecv(byte[] buffer, byte pduType)
@@ -40,20 +72,37 @@ namespace Screenary
 		
 		private void ProcessPDU(byte[] buffer, byte pduType)
 		{
+			MemoryStream stream = new MemoryStream(buffer);
+			BinaryReader s = new BinaryReader(stream);
+			
+			pduType = PDU_SURFACE_COMMAND_RECEIVER;
+			
+			switch (pduType)
+			{
+				case PDU_SURFACE_COMMAND_RECEIVER:
+					RecvSurfaceCommand(s);
+					return;
+				
+				default:
+					return;
+			}
 
 		}
 		
 		public void ChannelThreadProc()
 		{
-			lock (channelLock)
+			while(true)
 			{
-				while (queue.Count < 1)
+				lock (channelLock)
 				{
-					Monitor.Wait(channelLock);
+					while (queue.Count < 1)
+					{
+						Monitor.Wait(channelLock);
+					}
+					
+					PDU pdu = (PDU) queue.Dequeue();
+					ProcessPDU(pdu.Buffer, pdu.Type);
 				}
-				
-				PDU pdu = (PDU) queue.Dequeue();
-				ProcessPDU(pdu.Buffer, pdu.Type);
 			}
 		}
 	}

--- a/Server/Broadcaster.cs
+++ b/Server/Broadcaster.cs
@@ -13,7 +13,7 @@ namespace Screenary.Server
 	 * Broadcaster server, current implementation listens for TCP clients 
 	 * and broadcasts contents of data/rfx_sample.pcap within 20 seconds
 	 */ 
-	public class Broadcaster : ITransportListener
+	public class Broadcaster : ITransportListener, ISurfaceServer
 	{		
 		
 		/* Server socket */
@@ -34,8 +34,8 @@ namespace Screenary.Server
 		
 		public void OnAcceptClient(TransportClient transportClient)
 		{
-			Console.WriteLine("OnAcceptClient");
-			new Client(transportClient, ScreenSessions.Instance);
+			Console.WriteLine("Broadcaster.OnAcceptClient");
+			new Client(transportClient, SessionManager.Instance, this);
 		}
 		
 		/**
@@ -45,7 +45,14 @@ namespace Screenary.Server
 		 */
 		public void addPDU(PDU pdu, char[] sessionKey)
 		{
-			ScreenSessions.Instance.addPDU(pdu, sessionKey);
+			SessionManager.Instance.addPDU(pdu, sessionKey);
+		}
+				
+		public void OnSurfaceCommand(char[] sessionKey, byte[] buffer)
+		{
+			Console.WriteLine("Broadcaster.OnSurfaceCommand");
+			PDU pdu = new PDU(buffer, 0, 1);
+			this.addPDU(pdu, sessionKey);
 		}
 		
 	}

--- a/Server/ScreencastingSession.cs
+++ b/Server/ScreencastingSession.cs
@@ -19,8 +19,8 @@ namespace Screenary.Server
 		
 		public struct User
 		{
-			public UInt32 receiverId;
-			public string receiverUsername;
+			public UInt32 sessionId;
+			public string username;
 		}
 		
 		public ScreencastingSession(char[] sessionKey, UInt32 senderId, string senderUsername, string sessionPassword)
@@ -45,8 +45,8 @@ namespace Screenary.Server
 			//joinedClients.Remove(client);
 			
 			User user;
-			user.receiverId = id;
-			user.receiverUsername = username;
+			user.sessionId = id;
+			user.username = username;
 			authenticatedClients.TryAdd(client, user);
 		}
 		
@@ -60,8 +60,8 @@ namespace Screenary.Server
 			while(!done)
 			{
 				User user;
-				user.receiverId = id;
-				user.receiverUsername = username;
+				user.sessionId = id;
+				user.username = username;
 				authenticatedClients.TryAdd(client, user);
 				done = true;
 			}
@@ -113,7 +113,7 @@ namespace Screenary.Server
 			ArrayList participantUsernames = new ArrayList();
 			foreach(User user in authenticatedClients.Values)
 			{
-				participantUsernames.Add(user.receiverUsername);
+				participantUsernames.Add(user.username);
 			}
 			return participantUsernames;
 		}

--- a/Server/ScreencastingSession.cs
+++ b/Server/ScreencastingSession.cs
@@ -1,126 +1,209 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Collections.Concurrent;
-using System.Runtime.CompilerServices;
+using System.IO;
 
 namespace Screenary.Server
 {
-	public class ScreencastingSession
+	public class ScreenSessions: IClientRequestListener
 	{
-		public char[] sessionKey {get; set;}
-		public UInt32 senderId {get; set;}
-		public string senderUsername {get; set;}
-		private string sessionPassword;
 		
-		/* Lists of TCP Clients */
-		public ConcurrentDictionary<Client, UInt32> joinedClients {get; set;}
-		public ConcurrentDictionary<Client, User> authenticatedClients {get; set;}
+   	    private static ScreenSessions instance;
+		static readonly object padlock = new object();
+		private Dictionary<string, ScreencastingSession> sessions; 
+		private static UInt32 sessionId = 100;
 		
-		public struct User
+		public ScreenSessions ()
 		{
-			public UInt32 receiverId;
-			public string receiverUsername;
+			this.sessions = new Dictionary<string, ScreencastingSession>();
 		}
 		
-		public ScreencastingSession(char[] sessionKey, UInt32 senderId, string senderUsername, string sessionPassword)
-		{
-			this.sessionKey = sessionKey;
-			this.senderId = senderId;
-			this.senderUsername = senderUsername;
-			this.sessionPassword = sessionPassword;
-			joinedClients = new ConcurrentDictionary<Client, UInt32>();
-			authenticatedClients = new ConcurrentDictionary<Client, User>();
-		}
+		public static ScreenSessions Instance
+	    {
+	    	get 
+	      	{
+				//lock for multithreading support
+				lock (padlock)
+            	{
+		        	if (instance == null)
+		         	{
+		            	instance = new ScreenSessions();
+		         	}
+		         	return instance;
+				}
+	      	}
+	   	}
 		
-		[MethodImpl(MethodImplOptions.Synchronized)]
-		public void AddJoinedUser(Client client, UInt32 id)
+		public void addPDU(PDU pdu, char[] sessionKey)
 		{
-			joinedClients.TryAdd(client, id);
-		}
-		
-		[MethodImpl(MethodImplOptions.Synchronized)]
-		public void AddFirstUser(Client client, UInt32 id, string username)
-		{
-			//joinedClients.Remove(client);
-			
-			User user;
-			user.receiverId = id;
-			user.receiverUsername = username;
-			authenticatedClients.TryAdd(client, user);
-		}
-		
-		[MethodImpl(MethodImplOptions.Synchronized)]
-		public void AddAuthenticatedUser(Client client, UInt32 id, string username)
-		{
-			//joinedClients.Remove(client);
-			
-			Boolean done = false;
-			
-			while(!done)
+			string sessionKeyString = new string(sessionKey);
+			if(isSessionAlive(sessionKeyString))
 			{
-				User user;
-				user.receiverId = id;
-				user.receiverUsername = username;
-				authenticatedClients.TryAdd(client, user);
-				done = true;
-			}
-			
-			UpdateNotifications("joined",username);
-		}
-				
-		[MethodImpl(MethodImplOptions.Synchronized)]
-		public void UpdateAllParticipants()
-		{
-			foreach(Client client in authenticatedClients.Keys)
-			{
-				client.OnSessionParticipantListUpdated(GetParticipantUsernames());
+				ScreencastingSession session = sessions[sessionKeyString];
+				foreach (Client client in session.authenticatedClients.Keys)
+				{
+					client.addPDU(pdu);
+				}
 			}
 		}
 		
-		[MethodImpl(MethodImplOptions.Synchronized)]
-		public void UpdateNotifications(string type, string username)
+		public void OnSessionJoinRequested(Client client, char[] sessionKey, ref UInt32 sessionId, ref UInt32 sessionStatus, ref byte sessionFlags)
 		{
-			foreach(Client client in authenticatedClients.Keys)
+			Console.WriteLine("ScreenSessions.OnSessionJoinRequested");
+			
+			string sessionKeyString = new string(sessionKey);
+			Console.WriteLine("SessionKey:{0}", sessionKeyString);
+			
+			if(isSessionAlive(sessionKeyString))
 			{
-				client.OnSessionNotificationUpdate(type,username);
+				ScreencastingSession screencastSession = sessions[sessionKeyString];
+				sessionId = GenerateUniqueId();
+				screencastSession.AddJoinedUser(client, sessionId);
+				sessionStatus = 0;
+				return;
 			}
+						
+			sessionStatus = 1;
+			
+		}
+		
+		public void OnSessionLeaveRequested(Client client, UInt32 sessionId, char[] sessionKey, ref UInt32 sessionStatus)
+		{
+			Console.WriteLine("ScreenSessions.OnSessionLeaveRequested");
+			
+			string sessionKeyString = new string(sessionKey);
+			Console.WriteLine("sessionId:{0} sessionKey:{1} ", sessionId, sessionKeyString);
+			
+			if(isSessionAlive(sessionKeyString))
+			{
+				ScreencastingSession screencastSession = sessions[sessionKeyString];
+				if(screencastSession.authenticatedClients.ContainsKey(client))
+				{
+					screencastSession.RemoveAuthenticatedUser(client);
+					OnSessionPartipantListUpdated(screencastSession.sessionKey);
+					sessionStatus = 0;
+					return;
+				}
+			}
+
+			sessionStatus = 1;
 		}
 
-		[MethodImpl(MethodImplOptions.Synchronized)]
-		public void RemoveAuthenticatedUser(Client client, string username)
+		public void OnSessionAuthenticationRequested(Client client, UInt32 sessionId, char[] sessionKey, string username, string password, ref UInt32 sessionStatus)
 		{
-			User user;
-			authenticatedClients.TryRemove(client, out user);
-			UpdateNotifications("left", username);
-		}		
-		
-		[MethodImpl(MethodImplOptions.Synchronized)]
-		public Boolean Authenticate(Client client, UInt32 sessionId, string username, string password)
-		{
-			Boolean isAuthenticated = (this.sessionPassword == password);
-			if(isAuthenticated)
-			{
-				this.AddAuthenticatedUser(client, sessionId, username);				
+			Console.WriteLine("ScreenSessions.OnSessionAuthenticationRequested");
+			Console.WriteLine("sessionId:{0} username:{1} password:{2}", sessionId, username, password);
+			
+			string sessionKeyString = new string(sessionKey);
+			
+			if(isSessionAlive(sessionKeyString))
+			{	
+				ScreencastingSession screencastSession = sessions[sessionKeyString];
+				if(screencastSession.Authenticate(client, sessionId, username, password))
+				{
+					OnSessionPartipantListUpdated(screencastSession.sessionKey);
+					sessionStatus = 0;
+					return;
+				}
 			}
 			
-			return isAuthenticated;
+			sessionStatus = 1;
 		}
 		
-		public ArrayList GetParticipantUsernames()
+		public void OnSessionCreateRequested(Client client, string username, string password, ref UInt32 sessionId, ref char[] sessionKey)
 		{
-			ArrayList participantUsernames = new ArrayList();
-			foreach(User user in authenticatedClients.Values)
+			Console.WriteLine("ScreenSessions.OnSessionCreateRequested");
+			Console.WriteLine("username:{0} password:{1}", username, password);
+			
+			sessionId = GenerateUniqueId();
+			sessionKey = GenerateUniqueKey();
+			string sessionKeyString = new string(sessionKey);
+
+			ScreencastingSession screencastSession = new ScreencastingSession(sessionKey, sessionId, username, password);
+			
+			sessions.Add(sessionKeyString, screencastSession);
+			screencastSession.AddAuthenticatedUser(client, sessionId, username);
+
+		}
+		
+		public void OnSessionTerminationRequested(Client client, UInt32 sessionId, char[] sessionKey, ref UInt32 sessionStatus)
+		{
+			Console.WriteLine("ScreenSessions.OnSessionTerminationRequested");
+			string sessionKeyString = new string(sessionKey);
+			Console.WriteLine("SessionId:{0}, SessionStatus:{1}, SessionKey:{2}", sessionId, sessionStatus, sessionKeyString);
+			
+			if(isSessionAlive(sessionKeyString))
 			{
-				participantUsernames.Add(user.receiverUsername);
+				/*Only the sender can terminate a session*/
+				ScreencastingSession screencastSession = sessions[sessionKeyString];
+				if(screencastSession.senderId == sessionId)
+				{
+					sessions.Remove(sessionKeyString);
+					screencastSession.authenticatedClients.Clear();
+					sessionStatus = 0;
+					return;
+				}
 			}
-			return participantUsernames;
+
+			sessionStatus = 1;
+		}	
+		
+		private void OnSessionPartipantListUpdated(char[] sessionKey)
+		{
+			Console.WriteLine("ScreenSessions.OnSessionPartipantsListSuccess");
+			string sessionKeyString = new string(sessionKey);
+			if(isSessionAlive(sessionKeyString))
+			{
+				ScreencastingSession session = sessions[sessionKeyString];
+				ArrayList participantUsernames = session.GetParticipantUsernames();
+				foreach(Client client in session.authenticatedClients.Keys)
+				{
+					client.OnSessionPartipantListUpdated(participantUsernames);
+				}
+			}
+		}	
+		
+		public void OnSessionOperationFail(string errorMessage)
+		{
+			Console.WriteLine("ScreenSessions.OnSessionOperationFail");
+		}	
+		
+		private char[] GenerateUniqueKey()
+		{
+			/*
+			string path = Path.GetRandomFileName(); //TODO This does not work for me. It did before but I think I messed something up (@Mar from TA)
+			string attemptSessionKey = path.Replace(".", "").Substring(0, 12).ToUpperInvariant();
+			char[] sessionKey = null;
+			while(sessions.ContainsKey(attemptSessionKey))
+			{
+				sessionKey = attemptSessionKey.ToCharArray();
+			}*/
+			
+			char[] sessionKey = "ABCDEF123456".ToCharArray();
+			
+			return sessionKey;
 		}
 		
-		[MethodImpl(MethodImplOptions.Synchronized)]
-		public bool isPasswordProtected()
+		private UInt32 GenerateUniqueId()
 		{
-			return (!sessionPassword.Equals(""));	
+			return sessionId++;
+		}
+		
+		private ScreencastingSession GetBySenderSessionId(UInt32 sessionId)
+		{
+			foreach(ScreencastingSession screencastSession in sessions.Values)
+			{
+				if(screencastSession.senderId == sessionId)
+				{
+					return screencastSession;
+				}
+			}
+			return null;
+		}
+		
+		private Boolean isSessionAlive(string sessionKeyString)
+		{
+			return sessions.ContainsKey(sessionKeyString);
 		}
 		
 	}

--- a/Server/ScreencastingSession.cs
+++ b/Server/ScreencastingSession.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
 
 namespace Screenary.Server
 {
@@ -12,8 +14,8 @@ namespace Screenary.Server
 		private string sessionPassword;
 		
 		/* Lists of TCP Clients */
-		public Dictionary<Client, UInt32> joinedClients {get; set;}
-		public Dictionary<Client, User> authenticatedClients {get; set;}
+		public ConcurrentDictionary<Client, UInt32> joinedClients {get; set;}
+		public ConcurrentDictionary<Client, User> authenticatedClients {get; set;}
 		
 		public struct User
 		{
@@ -27,15 +29,17 @@ namespace Screenary.Server
 			this.senderId = senderId;
 			this.senderUsername = senderUsername;
 			this.sessionPassword = sessionPassword;
-			joinedClients = new Dictionary<Client, UInt32>();
-			authenticatedClients = new Dictionary<Client, User>();
-		}
-
-		public void AddJoinedUser(Client client, UInt32 id)
-		{
-			joinedClients.Add(client, id);
+			joinedClients = new ConcurrentDictionary<Client, UInt32>();
+			authenticatedClients = new ConcurrentDictionary<Client, User>();
 		}
 		
+		[MethodImpl(MethodImplOptions.Synchronized)]
+		public void AddJoinedUser(Client client, UInt32 id)
+		{
+			joinedClients.TryAdd(client, id);
+		}
+		
+		[MethodImpl(MethodImplOptions.Synchronized)]
 		public void AddFirstUser(Client client, UInt32 id, string username)
 		{
 			//joinedClients.Remove(client);
@@ -43,9 +47,10 @@ namespace Screenary.Server
 			User user;
 			user.receiverId = id;
 			user.receiverUsername = username;
-			authenticatedClients.Add(client, user);
+			authenticatedClients.TryAdd(client, user);
 		}
 		
+		[MethodImpl(MethodImplOptions.Synchronized)]
 		public void AddAuthenticatedUser(Client client, UInt32 id, string username)
 		{
 			//joinedClients.Remove(client);
@@ -57,15 +62,14 @@ namespace Screenary.Server
 				User user;
 				user.receiverId = id;
 				user.receiverUsername = username;
-				authenticatedClients.Add(client, user);
+				authenticatedClients.TryAdd(client, user);
 				done = true;
 			}
 			
 			UpdateNotifications("joined",username);
 		}
-		
-	
-		
+				
+		[MethodImpl(MethodImplOptions.Synchronized)]
 		public void UpdateAllParticipants()
 		{
 			foreach(Client client in authenticatedClients.Keys)
@@ -74,6 +78,7 @@ namespace Screenary.Server
 			}
 		}
 		
+		[MethodImpl(MethodImplOptions.Synchronized)]
 		public void UpdateNotifications(string type, string username)
 		{
 			foreach(Client client in authenticatedClients.Keys)
@@ -82,12 +87,15 @@ namespace Screenary.Server
 			}
 		}
 
+		[MethodImpl(MethodImplOptions.Synchronized)]
 		public void RemoveAuthenticatedUser(Client client, string username)
 		{
-			authenticatedClients.Remove(client);
+			User user;
+			authenticatedClients.TryRemove(client, out user);
 			UpdateNotifications("left", username);
 		}		
 		
+		[MethodImpl(MethodImplOptions.Synchronized)]
 		public Boolean Authenticate(Client client, UInt32 sessionId, string username, string password)
 		{
 			Boolean isAuthenticated = (this.sessionPassword == password);
@@ -109,6 +117,7 @@ namespace Screenary.Server
 			return participantUsernames;
 		}
 		
+		[MethodImpl(MethodImplOptions.Synchronized)]
 		public bool isPasswordProtected()
 		{
 			return (!sessionPassword.Equals(""));	

--- a/Server/Server.csproj
+++ b/Server/Server.csproj
@@ -42,8 +42,8 @@
     <Compile Include="Client.cs" />
     <Compile Include="Surface.cs" />
     <Compile Include="ScreencastingSession.cs" />
-    <Compile Include="ScreenSessions.cs" />
     <Compile Include="IClientRequestListener.cs" />
+    <Compile Include="SessionManager.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/Server/Surface.cs
+++ b/Server/Surface.cs
@@ -4,7 +4,7 @@ namespace Screenary.Server
 {
 	public class Surface : SurfaceServer
 	{
-		public Surface(TransportClient transport) : base(transport)
+		public Surface(ISurfaceServer listener, TransportClient transport) : base(listener, transport)
 		{
 
 		}


### PR DESCRIPTION
ScreenSessions renamed to SessionManager

Sender can send updates to Broadcaster where the Broadcaster returns surface commands to all receivers
